### PR TITLE
Refresh formatting when `options` changes

### DIFF
--- a/addon/components/imput-money.js
+++ b/addon/components/imput-money.js
@@ -42,6 +42,10 @@ export default TextField.extend({
     this._super(...arguments);
   },
 
+  refresh: observer('options', function() {
+    this.$().maskMoney('mask');
+  }),
+
   setMask: observer('options', function(){
     this.$().maskMoney('destroy');
     this.$().maskMoney(this.get('options'));

--- a/addon/components/imput-money.js
+++ b/addon/components/imput-money.js
@@ -42,13 +42,9 @@ export default TextField.extend({
     this._super(...arguments);
   },
 
-  refresh: observer('options', function() {
-    this.$().maskMoney('mask');
-  }),
-
   setMask: observer('options', function(){
-    this.$().maskMoney('destroy');
     this.$().maskMoney(this.get('options'));
+    this.$().maskMoney('mask');
   }),
 
   setMaskedValue: observer('number', 'precision', 'decimal', function(){


### PR DESCRIPTION
The `input-money` component does not update when parameters are updated. For example, changing the `suffix` or `prefix` values will not update the display until the input fields receive focus. This PR adds an observer that refreshes the display whenever parameter values change.